### PR TITLE
Adds support for arm64 architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 Gemfile.lock
 **/.ropeproject
 playbook.retry
+.python-version

--- a/README.md
+++ b/README.md
@@ -24,9 +24,8 @@ With default values role will instanciate a 4 node cluster using latest kind rel
 | kind_registry_port     |           5000 | integer | false     | Host bind port for local docker registry                                           |
 | kind_proxy_deploy      |          false | bool    | false     | Deploy proxy registry container                                                    |
 | kind_proxy_hostname    |      localhost | string  | false     | Hostname for proxy registry                                                        |
-| kind_proxy_cleanup     |           true | string  | false     | Add proxy registry container to cluster configuration                                      |
+| kind_proxy_cleanup     |           true | string  | false     | Add proxy registry container to cluster configuration                              |
 | kind_nodes             |              4 | integer | false     | Cluster size                                                                       |
-
 ## Dependencies
 
 ### System
@@ -34,6 +33,10 @@ With default values role will instanciate a 4 node cluster using latest kind rel
 The below requirements are needed on the host that executes this module.
 * Linux 64 bit OS
 * kubectl binary is available on path
+
+This role is compatible with arm64 distributions. You must gather facts before running this role for this to work as intended.
+
+For this role to run on apple silicon devices you **must** export the environment variable `DOCKER_HOST` to `unix:///$HOME/.docker/run/docker.sock`. The default `unix:///var/run/docker.sock` is not available on MacOS
 
 ### Ansible
 

--- a/molecule/common/converge.yml
+++ b/molecule/common/converge.yml
@@ -3,7 +3,7 @@
 
   hosts: localhost
 
-  gather_facts: false
+  gather_facts: true
 
   roles:
 

--- a/molecule/common/destroy.yml
+++ b/molecule/common/destroy.yml
@@ -3,7 +3,7 @@
 
   hosts: localhost
 
-  gather_facts: false
+  gather_facts: true
 
   vars:
 

--- a/molecule/common/verify.yml
+++ b/molecule/common/verify.yml
@@ -3,7 +3,7 @@
 
   hosts: localhost
 
-  gather_facts: false
+  gather_facts: true
 
   tasks:
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,7 +65,19 @@
             url: "https://kind.sigs.k8s.io/dl/{{ kind_release }}/kind-linux-amd64"
             dest: "{{ _kind_bin }}"
             mode: 0755
-          when: not (kind_bin_file.stat.exists | bool)
+          when:
+            - not (kind_bin_file.stat.exists | bool)
+            - ansible_architecture | default('x86_64') == "x86_64"
+          changed_when: false
+
+        - name: download kind executable (ARM)
+          ansible.builtin.get_url:
+            url: "https://kind.sigs.k8s.io/dl/{{ kind_release }}/kind-linux-arm64"
+            dest: "{{ _kind_bin }}"
+            mode: 0755
+          when:
+            - not (kind_bin_file.stat.exists | bool)
+            - ansible_architecture | default('x86_64') == "arm64"
           changed_when: false
 
       rescue:


### PR DESCRIPTION
Adds support for arm64 architecture through the use of `ansible_architecture`.
Testing for various architectures is not possible without the use of self-hosted runners.