### PR TITLE
Adds support for darwin based os

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ With default values role will instanciate a 4 node cluster using latest kind rel
 ### System
 
 The below requirements are needed on the host that executes this module.
-* Linux 64 bit OS
+* Linux or Darwin 64 bit OS
 * kubectl binary is available on path
 
-This role is compatible with arm64 distributions. You must gather facts before running this role for this to work as intended.
+This role is compatible with arm64 and darwin distributions. You must gather facts before running this role for this to work as intended.
 
 For this role to run on apple silicon devices you **must** export the environment variable `DOCKER_HOST` to `unix:///$HOME/.docker/run/docker.sock`. The default `unix:///var/run/docker.sock` is not available on MacOS
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,8 @@ kind_proxy_container: "{{ kind_cluster_name }}-proxy"
 kind_proxy_hostname: "{{ kind_proxy_container }}"
 kind_proxy_cleanup: true
 kind_nodes: 4
+kind_release_family: "{{ (ansible_os_family == 'Darwin') | ternary('darwin', 'linux') }}"
+kind_release_architecture: "{{ kind_release_architecture_map[ansible_architecture] }}"
+kind_release_architecture_map:
+  x84_64: amd64
+  arm64: arm64

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -62,22 +62,10 @@
 
         - name: download kind executable
           ansible.builtin.get_url:
-            url: "https://kind.sigs.k8s.io/dl/{{ kind_release }}/kind-linux-amd64"
+            url: "https://kind.sigs.k8s.io/dl/{{ kind_release }}/kind-{{ kind_release_family }}-{{ kind_release_architecture }}"
             dest: "{{ _kind_bin }}"
             mode: 0755
-          when:
-            - not (kind_bin_file.stat.exists | bool)
-            - ansible_architecture | default('x86_64') == "x86_64"
-          changed_when: false
-
-        - name: download kind executable (ARM)
-          ansible.builtin.get_url:
-            url: "https://kind.sigs.k8s.io/dl/{{ kind_release }}/kind-linux-arm64"
-            dest: "{{ _kind_bin }}"
-            mode: 0755
-          when:
-            - not (kind_bin_file.stat.exists | bool)
-            - ansible_architecture | default('x86_64') == "arm64"
+          when: not (kind_bin_file.stat.exists | bool)
           changed_when: false
 
       rescue:


### PR DESCRIPTION
Adds support for darwin operating systems (MacOS). 
Downloading the Linux binary on a Darwin system results in `[Errno 8] Exec format error` this fixes this issue by making the task that downloads the binary architecture and family aware.