### PR TITLE
Changes default registry port to avoid system conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ With default values role will instanciate a 4 node cluster using latest kind rel
 | kind_registry_deploy   |          false | bool    | false     | Create local registry container                                                    |
 | kind_registry_hostname |      localhost | string  | localhost | Hostname for local docker registry                                                 |
 | kind_registry_cleanup  |           true | string  | false     | Destroy local registry container with cluster                                      |
-| kind_registry_port     |           5000 | integer | false     | Host bind port for local docker registry                                           |
+| kind_registry_port     |          49153 | integer | false     | Host bind port for local docker registry                                           |
 | kind_proxy_deploy      |          false | bool    | false     | Deploy proxy registry container                                                    |
 | kind_proxy_hostname    |      localhost | string  | false     | Hostname for proxy registry                                                        |
 | kind_proxy_cleanup     |           true | string  | false     | Add proxy registry container to cluster configuration                              |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ kind_network_addr: 172.19.0.0/16
 kind_registry_deploy: true
 kind_registry_container: "{{ kind_cluster_name }}-registry"
 kind_registry_hostname: "localhost"
-kind_registry_port: 5000
+kind_registry_port: 49153
 kind_registry_cleanup: true
 kind_proxy_deploy: true
 kind_proxy_container: "{{ kind_cluster_name }}-proxy"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -25,6 +25,6 @@ provisioner:
           kind_cluster_name: molecule-kind
           kind_nodes: 4
           kind_registry_deploy: true
-          kind_registry_port: 5000
+          kind_registry_port: 49153
 verifier:
   name: ansible

--- a/molecule/registry/molecule.yml
+++ b/molecule/registry/molecule.yml
@@ -26,6 +26,6 @@ provisioner:
           kind_nodes: 3
           kind_proxy_deploy: true
           kind_registry_deploy: true
-          kind_registry_port: 5000
+          kind_registry_port: 49153
 verifier:
   name: ansible

--- a/molecule/singlenode/molecule.yml
+++ b/molecule/singlenode/molecule.yml
@@ -26,6 +26,6 @@ provisioner:
           kind_nodes: 1
           kind_proxy_deploy: false
           kind_registry_deploy: false
-          kind_registry_port: 5000
+          kind_registry_port: 49153
 verifier:
   name: ansible

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -177,12 +177,12 @@
           - |-
           {% endif -%}
           {%- if (kind_registry_deploy | bool) %}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ kind_registry_hostname }}:{{kind_registry_port}}"]
-              endpoint = ["http://{{ kind_registry_hostname }}:{{kind_registry_port}}"]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ kind_registry_hostname }}:{{ kind_registry_port }}"]
+              endpoint = ["http://{{ kind_registry_hostname }}:{{ kind_registry_port }}"]
           {% endif -%}
           {%- if (kind_proxy_deploy | bool) %}
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-              endpoint = ["http://{{ kind_proxy_hostname }}:{{kind_registry_port}}"]
+              endpoint = ["http://{{ kind_proxy_hostname }}:{{ kind_registry_port }}"]
           {% endif -%}
 
     - name: create cluster configuration file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,7 +114,7 @@
 
         - name: deploy docker private registry
           ansible.builtin.command: >
-            docker run --name {{ kind_registry_container }} --net {{ kind_network_name }} --net-alias {{ kind_registry_hostname }} -d -p 5000:5000 registry:2
+            docker run --name {{ kind_registry_container }} --net {{ kind_network_name }} --net-alias {{ kind_registry_hostname }} -d -p {{ kind_registry_port }}:{{ kind_registry_port }} registry:2
           when:
             - kind_registry_deploy | bool
             - not kind_registry_query.exists
@@ -177,12 +177,12 @@
           - |-
           {% endif -%}
           {%- if (kind_registry_deploy | bool) %}
-            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ kind_registry_hostname }}:5000"]
-              endpoint = ["http://{{ kind_registry_hostname }}:5000"]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."{{ kind_registry_hostname }}:{{kind_registry_port}}"]
+              endpoint = ["http://{{ kind_registry_hostname }}:{{kind_registry_port}}"]
           {% endif -%}
           {%- if (kind_proxy_deploy | bool) %}
             [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-              endpoint = ["http://{{ kind_proxy_hostname }}:5000"]
+              endpoint = ["http://{{ kind_proxy_hostname }}:{{kind_registry_port}}"]
           {% endif -%}
 
     - name: create cluster configuration file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,7 +114,7 @@
 
         - name: deploy docker private registry
           ansible.builtin.command: >
-            docker run --name {{ kind_registry_container }} --net {{ kind_network_name }} --net-alias {{ kind_registry_hostname }} -d -p {{ kind_registry_port }}:{{ kind_registry_port }} registry:2
+            docker run --name {{ kind_registry_container }} --net {{ kind_network_name }} --net-alias {{ kind_registry_hostname }} -d -p {{ kind_registry_port }}:5000 registry:2
           when:
             - kind_registry_deploy | bool
             - not kind_registry_query.exists


### PR DESCRIPTION
Changes default registry port to avoid system conflicts. Port 5000 is used in darwin systems for AirPlay
Port 49153 was chosen as it belongs to the "free" TCP/UDP port range (49152-65535).
This PR also changes the places where this port was hardcoded and uses the `kind_registry_port` variable in these places.